### PR TITLE
Fix AttributeError: 'numpy.float32' object has no attribute 'int'

### DIFF
--- a/boxmot/strongsort/sort/track.py
+++ b/boxmot/strongsort/sort/track.py
@@ -276,7 +276,7 @@ class Track:
             The associated detection.
         """
         self.conf = conf
-        self.class_id = class_id.int()
+        self.class_id = np.int32(class_id)
         self.mean, self.covariance = self.kf.update(self.mean, self.covariance, detection.to_xyah(), detection.confidence)
 
         feature = detection.feature / np.linalg.norm(detection.feature)


### PR DESCRIPTION
In version NumPy 1.24.0, the deprecated np.int has been removed.