### PR TITLE
Add filtering of result of all yolo models by classes

### DIFF
--- a/examples/multi_yolo_backend.py
+++ b/examples/multi_yolo_backend.py
@@ -3,6 +3,7 @@ import numpy as np
 import torch
 
 from boxmot.utils.checks import TestRequirements
+
 tr = TestRequirements()
 
 from ultralytics.yolo.engine.results import Boxes, Results
@@ -40,21 +41,21 @@ class MultiYolo():
         # already loaded
         elif 'yolov8' in self.model_name:
             self.model = model
-            
+
     def try_sg_import(self):
         try:
             import super_gradients  # for linear_assignment
         except (ImportError, AssertionError, AttributeError):
             tr.check_packages(('super-gradients==3.1.1',))  # install
-            
+
     def __call__(self, im, im0s):
         if 'yolo_nas' in self.model_name or 'yolox' in self.model_name:
             prediction = next(iter(
                 self.model.predict(im0s,
                                    iou=self.args.iou,
                                    conf=self.args.conf)
-                )
-            ).prediction # Returns a generator of the batch, which here is 1
+            )
+            ).prediction  # Returns a generator of the batch, which here is 1
             preds = np.concatenate(
                 [
                     prediction.bboxes_xyxy,
@@ -62,6 +63,8 @@ class MultiYolo():
                     prediction.labels[:, np.newaxis]
                 ], axis=1
             )
+            if self.args.classes:  # Filter boxes by classes
+                preds = preds[np.isin(preds[:, 5], self.args.classes)]
             preds = torch.from_numpy(preds)
             preds[:, 0:4] = preds[:, 0:4].int()
             # SG models can generate negative values
@@ -75,8 +78,9 @@ class MultiYolo():
         else:
             LOGGER.error('The Yolo model you selected is not available')
             exit()
+
         return preds
-    
+
     def overwrite_results(self, i, im0_shape, predictor):
         # overwrite bbox results with tracker predictions
         if predictor.tracker_outputs[i].size != 0:
@@ -85,7 +89,7 @@ class MultiYolo():
                 boxes=torch.from_numpy(predictor.tracker_outputs[i]).to(self.device),
                 orig_shape=im0_shape,  # (height, width)
             )
-    
+
     def filter_results(self, i, predictor):
         if predictor.tracker_outputs[i].size != 0:
             # filter boxes masks and pose results by tracking results
@@ -93,7 +97,7 @@ class MultiYolo():
             yolo_confs = predictor.results[i].boxes.conf.cpu().numpy()
             tracker_confs = predictor.tracker_outputs[i][:, 5]
             mask = np.in1d(yolo_confs, tracker_confs)
-            
+
             if predictor.results[i].masks is not None:
                 predictor.results[i].masks = predictor.results[i].masks[mask]
                 predictor.results[i].boxes = predictor.results[i].boxes[mask]
@@ -101,7 +105,7 @@ class MultiYolo():
                 predictor.results[i].boxes = predictor.results[i].boxes[mask]
                 predictor.results[i].keypoints = predictor.results[i].keypoints[mask]
 
-    def postprocess(self, path, preds, im ,im0s, predictor):
+    def postprocess(self, path, preds, im, im0s, predictor):
         if 'yolo_nas' in self.model_name or 'yolox' in self.model_name:
             predictor.results[0] = Results(
                 path=path,
@@ -113,11 +117,8 @@ class MultiYolo():
             predictor.results = predictor.postprocess(preds, im, im0s)
         return predictor.results
 
-        
-
 
 if __name__ == "__main__":
     yolo = MultiYolo(model='YOLO_NAS_S', device='cuda:0')
-    rgb = np.random.randint(255, size=(640, 640, 3),dtype=np.uint8)
+    rgb = np.random.randint(255, size=(640, 640, 3), dtype=np.uint8)
     yolo(rgb, rgb)
-            

--- a/examples/track.py
+++ b/examples/track.py
@@ -53,7 +53,6 @@ def run(args):
     
     model = YOLO(args['yolo_model'] if 'v8' in str(args['yolo_model']) else 'yolov8n')
     overrides = model.overrides.copy()
-    overrides['classes'] = args['classes']  # Add override to filter classes for yolov8n models
     model.predictor = TASK_MAP[model.task][3](overrides=overrides, _callbacks=model.callbacks)
     
     # extract task predictor

--- a/examples/track.py
+++ b/examples/track.py
@@ -3,9 +3,7 @@
 from pathlib import Path
 import torch
 import argparse
-import numpy as np
 import cv2
-from types import SimpleNamespace
 
 from boxmot.tracker_zoo import create_tracker
 from boxmot.utils import ROOT, WEIGHTS
@@ -18,10 +16,9 @@ tr.check_packages(('ultralytics',))  # install
 
 from ultralytics.yolo.engine.model import YOLO, TASK_MAP
 
-from ultralytics.yolo.utils import SETTINGS, colorstr, ops, is_git_dir, IterableSimpleNamespace
-from ultralytics.yolo.utils.checks import check_imgsz, print_args
+from ultralytics.yolo.utils import colorstr, ops, IterableSimpleNamespace
+from ultralytics.yolo.utils.checks import check_imgsz
 from ultralytics.yolo.utils.files import increment_path
-from ultralytics.yolo.engine.results import Boxes
 from ultralytics.yolo.data.utils import VID_FORMATS
 from ultralytics.yolo.utils.plotting import save_one_box
 

--- a/examples/track.py
+++ b/examples/track.py
@@ -137,7 +137,7 @@ def run(args):
             model.overwrite_results(i, im0.shape[:2], predictor)
             
             # write inference results to a file or directory   
-            if predictor.args.verbose or predictor.args.save or predictor.args.save_txt or predictor.args.show or predict.args.save_id_crops:
+            if predictor.args.verbose or predictor.args.save or predictor.args.save_txt or predictor.args.show or predictor.args.save_id_crops:
                 
                 s += predictor.write_results(i, predictor.results, (p, im, im0))
                 predictor.txt_path = Path(predictor.txt_path)

--- a/examples/track.py
+++ b/examples/track.py
@@ -95,7 +95,6 @@ def run(args):
         predictor.run_callbacks('on_predict_batch_start')
         predictor.batch = batch
         path, im0s, vid_cap, s = batch
-        visualize = increment_path(save_dir / Path(path[0]).stem, exist_ok=True, mkdir=True) if predictor.args.visualize and (not predictor.dataset.source_type.tensor) else False
 
         n = len(im0s)
         predictor.results = [None] * n

--- a/examples/track.py
+++ b/examples/track.py
@@ -53,6 +53,7 @@ def run(args):
     
     model = YOLO(args['yolo_model'] if 'v8' in str(args['yolo_model']) else 'yolov8n')
     overrides = model.overrides.copy()
+    overrides['classes'] = args['classes']  # Add override to filter classes for yolov8n models
     model.predictor = TASK_MAP[model.task][3](overrides=overrides, _callbacks=model.callbacks)
     
     # extract task predictor


### PR DESCRIPTION
First of all, thank you for amazing repo. I noticed that track.py is missing filtering of yolo models results based on classes provided by the user and have added a fix for it. Also, fixed 2 minor bugs. Most commits are atomic, so you each commit message should be self-explanatory.

The proposed solution worked (tested with various models) but I didnt like that changes for yolox_n, yolo_nas are in `examples/multi_yolo_backend.py` whereas changes for yolov8n are in `examples/track.py`,  however I went for this solution as filtering of results for yolov8n is provided by the Predictor using nms implementation. 
