### PR TITLE
Fix ECC Redundancy in StrongSORT

### DIFF
--- a/boxmot/trackers/strongsort/sort/track.py
+++ b/boxmot/trackers/strongsort/sort/track.py
@@ -255,8 +255,11 @@ class Track:
         else:
             return eye
 
-    def camera_update(self, previous_frame, next_frame):
-        warp_matrix, src_aligned = self.ECC(previous_frame, next_frame)
+    def camera_update(self, previous_frame, next_frame, ecc_results=None):
+        if ecc_results is None:
+            warp_matrix, src_aligned = self.ECC(previous_frame, next_frame)
+        else:
+            warp_matrix, src_aligned = ecc_results
         if warp_matrix is None and src_aligned is None:
             return
         [a, b] = warp_matrix

--- a/boxmot/trackers/strongsort/sort/tracker.py
+++ b/boxmot/trackers/strongsort/sort/tracker.py
@@ -73,7 +73,7 @@ class Tracker:
 
     def camera_update(self, previous_img, current_img):
         if len(self.tracks) > 0:
-            warp_matrix, src_aligned = self.ECC(previous_frame, next_frame)
+            warp_matrix, src_aligned = self.tracks[0].ECC(previous_frame, next_frame)
         for track in self.tracks:
             track.camera_update(previous_img, current_img, ecc_results=(warp_matrix, src_aligned))
 

--- a/boxmot/trackers/strongsort/sort/tracker.py
+++ b/boxmot/trackers/strongsort/sort/tracker.py
@@ -72,8 +72,10 @@ class Tracker:
             track.mark_missed()
 
     def camera_update(self, previous_img, current_img):
+        if len(self.tracks) > 0:
+            warp_matrix, src_aligned = self.ECC(previous_frame, next_frame)
         for track in self.tracks:
-            track.camera_update(previous_img, current_img)
+            track.camera_update(previous_img, current_img, ecc_results=(warp_matrix, src_aligned))
 
     def pred_n_update_all_tracks(self):
         """Perform predictions and updates for all tracks by its own predicted state."""


### PR DESCRIPTION
We just found a runtime performance bug in StrongSORT.
It seems like StrongSORT calls ECC for every object detected for each frame.
Instead, it should only call ECC once perframe and share the ECC results across all objects.

In our experiment, this fix gives 4x runtime improvement to StrongSORT.