### PR TITLE
Master

### DIFF
--- a/boxmot/trackers/hybridsort/__init__.py
+++ b/boxmot/trackers/hybridsort/__init__.py
@@ -1,0 +1,1 @@
+# Mikel Broström 🔥 Yolo Tracking 🧾 AGPL-3.0 license


### PR DESCRIPTION
This PR fixes the following import error:

```bash
○ → python
Python 3.8.11 (default, Nov 15 2022, 09:08:50) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import boxmot
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "$HOME/.pyenv/versions/person_reid/lib/python3.8/site-packages/boxmot/__init__.py", line 10, in <module>
    from boxmot.trackers.hybridsort.hybridsort import HybridSORT
ModuleNotFoundError: No module named 'boxmot.trackers.hybridsort'
```

a simple `__init__.py` should be added to `boxmot/trackers/hybridsort`