### PR TITLE
Update reid_multibackend.py

### DIFF
--- a/boxmot/appearance/reid_multibackend.py
+++ b/boxmot/appearance/reid_multibackend.py
@@ -71,13 +71,14 @@ class ReIDDetectMultiBackend(nn.Module):
                 show_downloadable_models()
                 exit()
 
-        # Build model
-        self.model = build_model(
-            model_name,
-            num_classes=get_nr_classes(w),
-            pretrained=not (w and w.is_file()),
-            use_gpu=device,
-        )
+        # Build model for pytorch only
+        if self.pt or self.jit:
+            self.model = build_model(
+                model_name,
+                num_classes=get_nr_classes(w),
+                pretrained=not (w and w.is_file()),
+                use_gpu=device,
+            )
 
         if self.pt:  # PyTorch
             # populate model arch with weights


### PR DESCRIPTION
## Problem: Trying to load custom ReID model (ONNX and OpenVINO)

I tried to load a custom OpenVINO weight file but get the error below:
```
KeyError: "Unknown model: None. 
Must be one of ['resnet50', 'resnet101', 'mobilenetv2_x1_0', 'mobilenetv2_x1_4', 'hacnn', 'mlfn', 'osnet_x1_0', 'osnet_x0_75', 'osnet_x0_5', 'osnet_x0_25', 'osnet_ibn_x1_0', 'osnet_ain_x1_0', 'osnet_ain_x0_75', 'osnet_ain_x0_5', 'osnet_ain_x0_25', 'lmbn_n', 'clip']"
```
Then, I noticed in [line 141](https://github.com/mikel-brostrom/yolo_tracking/blob/774e13322f31931e42ace0f39e572f6c77046a00/boxmot/appearance/reid_multibackend.py#L141), a ```self.network``` is initialized to load the OpenVINO weight file.
If seems to me that, the ```self.model``` should only used for ```.pt``` or ```.jit``` file. 
For example, ```self.network``` and ```self.session``` are used instead of ```self.model``` for OpenVINO and ONNX weight files.
But in [line 75](https://github.com/mikel-brostrom/yolo_tracking/blob/774e13322f31931e42ace0f39e572f6c77046a00/boxmot/appearance/reid_multibackend.py#L75) of ```ReIDDetectMultiBackend```, ```self.model``` is build using ```build_model()```, regardless of the weight file suffix.

## Changes
In ```reid_multibackend.py```,I added an if statement, so that the ```self.model = build_model()``` is only called when the weight file is .pt or .jit file.
You can refer [here](https://github.com/yjwong1999/yolo_tracking/blob/d6eff6834705352429d54275bfe2b6ae96eb0da5/boxmot/appearance/reid_multibackend.py#L74) for the minor changes I made.
I done similar experiment with .onnx file too, it seems to fix the bug.

Anyway, thanks a lot for the fantastic repo :)  😀 
I'm mostly implementing the detection/tracking using custom ReID model(s).
Your reid_multibackend framework really helps a lot!


