### PR TITLE
Fix finding second matching index in BoT-SORT

### DIFF
--- a/boxmot/trackers/botsort/bot_sort.py
+++ b/boxmot/trackers/botsort/bot_sort.py
@@ -249,7 +249,7 @@ class BoTSORT(object):
         confs = dets[:, 4]
 
         # find second round association detections
-        second_mask = np.logical_or(confs > self.track_low_thresh, confs < self.track_high_thresh)
+        second_mask = np.logical_and(confs > self.track_low_thresh, confs < self.track_high_thresh)
         dets_second = dets[second_mask]
 
         # find first round association detections


### PR DESCRIPTION
I've noticed an area for improvement in the BoT-SORT's current implementation. Specifically, the use of `logical_or` seems unconventional when determining the index for the second matching.

```diff
+ second_mask = np.logical_and(confs > self.track_low_thresh, confs < self.track_high_thresh)
- second_mask = np.logical_or(confs > self.track_low_thresh, confs < self.track_high_thresh)
```

I propose aligning our approach with other matching algorithms that utilize `logical_and`. This change should enhance the bot-sort's accuracy and maintain consistency with standard practices.