### PR TITLE
Fix cropping overflow issue

### DIFF
--- a/boxmot/appearance/reid_multibackend.py
+++ b/boxmot/appearance/reid_multibackend.py
@@ -186,10 +186,14 @@ class ReIDDetectMultiBackend(nn.Module):
         return types
 
     def preprocess(self, xyxys, img):
-        crops = []
+        h, w = img.shape[:2]
         # dets are of different sizes so batch preprocessing is not possible
         for box in xyxys:
             x1, y1, x2, y2 = box.astype('int')
+            x1 = max(0, x1)
+            y1 = max(0, y1)
+            x2 = min(w - 1, x2)
+            y2 = min(h - 1, y2)
             crop = img[y1:y2, x1:x2]
             # resize
             crop = cv2.resize(

--- a/boxmot/appearance/reid_multibackend.py
+++ b/boxmot/appearance/reid_multibackend.py
@@ -186,6 +186,7 @@ class ReIDDetectMultiBackend(nn.Module):
         return types
 
     def preprocess(self, xyxys, img):
+        crops = []
         h, w = img.shape[:2]
         # dets are of different sizes so batch preprocessing is not possible
         for box in xyxys:


### PR DESCRIPTION
Add clip to the coordinates to ensure the cropping results can be correct.
This might happen when having the negative coordinates or coordinates bigger than the image size.

Reference: [BoT-SORT](https://github.com/NirAharon/BoT-SORT/blob/251985436d6712aaf682aaaf5f71edb4987224bd/fast_reid/fast_reid_interfece.py#L81-L90).