### PR TITLE
Improvement for BoT-SORT

### DIFF
--- a/boxmot/motion/cmc/sof.py
+++ b/boxmot/motion/cmc/sof.py
@@ -118,19 +118,15 @@ class SparseOptFlow(CMCInterface):
                 return H
 
         # sparse otical flow for sparse features using Lucas-Kanade with pyramids
+        # calculate new positions of the keypoints between the previous frame (self.prev_img)
+        # and the current frame (img) using sparse optical flow (Lucas-Kanade with pyramids)
         try:
-            matchedKeypoints, status, err = cv2.calcOpticalFlowPyrLK(
+            next_keypoints, status, err = cv2.calcOpticalFlowPyrLK(
                 self.prev_img, img, self.prev_keypoints, None
             )
         except Exception as e:
             LOGGER.warning(f'calcOpticalFlowPyrLK failed: {e}')
             return H
-
-        # calculate new positions of the keypoints between the previous frame (self.prev_img)
-        # and the current frame (img) using sparse optical flow (Lucas-Kanade with pyramids)
-        next_keypoints, status, err = cv2.calcOpticalFlowPyrLK(
-            self.prev_img, img, self.prev_keypoints, None
-        )
 
         # for simplicity, if no keypoints are found, we discard the frame
         if next_keypoints is None:

--- a/boxmot/trackers/botsort/bot_sort.py
+++ b/boxmot/trackers/botsort/bot_sort.py
@@ -196,6 +196,7 @@ class BoTSORT(object):
         appearance_thresh: float = 0.25,
         cmc_method: str = "sparseOptFlow",
         frame_rate=30,
+        fuse_first_associate: bool = False,
     ):
         self.tracked_stracks = []  # type: list[STrack]
         self.lost_stracks = []  # type: list[STrack]
@@ -222,6 +223,7 @@ class BoTSORT(object):
         )
 
         self.cmc = SparseOptFlow()
+        self.fuse_first_associate = fuse_first_associate
 
     def update(self, dets, img):
         assert isinstance(
@@ -288,6 +290,8 @@ class BoTSORT(object):
         # Associate with high score detection boxes
         ious_dists = iou_distance(strack_pool, detections)
         ious_dists_mask = ious_dists > self.proximity_thresh
+        if self.fuse_first_associate:
+          ious_dists = fuse_score(ious_dists, detections)
 
         emb_dists = embedding_distance(strack_pool, detections) / 2.0
         emb_dists[emb_dists > self.appearance_thresh] = 1.0


### PR DESCRIPTION
Me again:)

Below are some improvements about BoT-SORT:

1. **Integration of a Fusing Option**: The first enhancement involves the addition of a fusing option within BoT-SORT. In the [original implementation](https://github.com/NirAharon/BoT-SORT/blob/251985436d6712aaf682aaaf5f71edb4987224bd/tracker/bot_sort.py#L306-L307), there is a consideration for fusing scores prior to the initial association, specifically for datasets other than MOT20. Through my experimentation, I have observed notable enhancements in performance on the MOT17 dataset, evidenced by an approximate 0.6 improvement in the HOTA metric.
2. **Optimization of Optical Flow Computation**: The second improvement addresses computational efficiency. Eliminating redundant calculations in the process of computing optical flow can save the computation time.

(**Additional Observations**: In my exploration, I also discovered that official version for the Kalman Filter (as utilized in ByteTrack) in conjunction with CMC yields a slightly better results. However, I have chosen to leave these components unchanged in the current iteration of the algorithm.)