### PR TITLE
Fix HybridSort numpy datatypes.

### DIFF
--- a/boxmot/trackers/hybridsort/association.py
+++ b/boxmot/trackers/hybridsort/association.py
@@ -672,13 +672,13 @@ def embedding_distance(tracks_feat, detections_feat, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks_feat), len(detections_feat)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks_feat), len(detections_feat)), dtype=np.float64)
     if cost_matrix.size == 0:
         return cost_matrix
-    # det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)    # [detection_num, emd_dim]
+    # det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float64)    # [detection_num, emd_dim]
     # #for i, track in enumerate(tracks):
     #     #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    # track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)    # [track_num, emd_dim]
+    # track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float64)    # [track_num, emd_dim]
     # Nomalized features, metric: cosine, [track_num, detection_num]
     cost_matrix = np.maximum(0.0, cdist(tracks_feat, detections_feat, metric))
     return cost_matrix

--- a/boxmot/trackers/hybridsort/hybridsort.py
+++ b/boxmot/trackers/hybridsort/hybridsort.py
@@ -408,10 +408,7 @@ class HybridSORT(object):
         ret = []
         for t, trk in enumerate(trks):
             pos, kalman_score, simple_score = self.trackers[t].predict()
-            try:
-                trk[:6] = [pos[0][0], pos[0][1], pos[0][2], pos[0][3], kalman_score, simple_score[0]]
-            except Exception:
-                trk[:6] = [pos[0][0], pos[0][1], pos[0][2], pos[0][3], kalman_score, simple_score]
+            trk[:6] = [pos[0][0], pos[0][1], pos[0][2], pos[0][3], kalman_score[0], simple_score]
             if np.any(np.isnan(pos)):
                 to_del.append(t)
         trks = np.ma.compress_rows(np.ma.masked_invalid(trks))

--- a/boxmot/trackers/hybridsort/hybridsort.py
+++ b/boxmot/trackers/hybridsort/hybridsort.py
@@ -435,11 +435,11 @@ class HybridSORT(object):
         """
         if self.EG_weight_high_score > 0 and self.TCM_first_step:
             track_features = np.asarray([track.smooth_feat for track in self.trackers],
-                                        dtype=np.float)
+                                        dtype=np.float64)
             emb_dists = embedding_distance(track_features, id_feature_keep).T
             if self.with_longterm_reid or self.with_longterm_reid_correction:
                 long_track_features = np.asarray([np.vstack(list(track.features)).mean(0) for track in self.trackers],
-                                                 dtype=np.float)
+                                                 dtype=np.float64)
                 assert track_features.shape == long_track_features.shape
                 long_emb_dists = embedding_distance(long_track_features, id_feature_keep).T
                 assert emb_dists.shape == long_emb_dists.shape
@@ -487,7 +487,7 @@ class HybridSORT(object):
                     )
                     iou_left_thre = iou_left
                 if self.EG_weight_low_score > 0:
-                    u_track_features = np.asarray([track.smooth_feat for track in u_tracklets], dtype=np.float)
+                    u_track_features = np.asarray([track.smooth_feat for track in u_tracklets], dtype=np.float64)
                     emb_dists_low_score = embedding_distance(u_track_features, id_feature_second).T
                     matched_indices = linear_assignment(-iou_left + self.EG_weight_low_score * emb_dists_low_score,
                                                         )


### PR DESCRIPTION
This fixes the following issue: https://github.com/mikel-brostrom/yolo_tracking/issues/1221
It also includes a fix for an error in the update method, where datatypes did not match with the return types of predict.