### PR TITLE
removes extra print statement in matching.py

### DIFF
--- a/boxmot/utils/matching.py
+++ b/boxmot/utils/matching.py
@@ -113,7 +113,6 @@ def iou_distance(atracks, btracks):
     if ious.size == 0:
         return ious
     _ious = iou_batch(atlbrs, btlbrs)
-    print(_ious)
 
     cost_matrix = 1 - _ious
 


### PR DESCRIPTION
I noticed extra terminal output when running Boxmot with BoT-SORT, due to an extra print() statement. Thanks for a really useful repo!