### PR TITLE
fix: make --verbose in cli.py enable logging instead of disabling

### DIFF
--- a/boxmot/engine/cli.py
+++ b/boxmot/engine/cli.py
@@ -66,7 +66,7 @@ def main():
                                help='path to precomputed embeddings file')
     common_parser.add_argument('--exp-folder-path', type=Path,
                                help='path to experiment folder')
-    common_parser.add_argument('--verbose', action='store_false',
+    common_parser.add_argument('--verbose', action='store_true',
                                help='print detailed logs')
     common_parser.add_argument('--agnostic-nms', action='store_true',
                                help='class-agnostic NMS')


### PR DESCRIPTION
Make --verbose in cli.py enable logging instead of disabling. To be consistent with the rest of the project.