### PR TITLE
Raise error for unknown tracker types

### DIFF
--- a/boxmot/tracker_zoo.py
+++ b/boxmot/tracker_zoo.py
@@ -33,6 +33,9 @@ def create_tracker(
 
     Returns:
     - An instance of the selected tracker.
+
+    Raises:
+    - ValueError: If `tracker_type` is not recognized.
     """
 
     # Load configuration from file or use provided dictionary
@@ -65,7 +68,7 @@ def create_tracker(
 
     # Check if the tracker type exists in the mapping
     if tracker_type not in tracker_mapping:
-        print("Error: No such tracker found.")
+        raise ValueError(f"Unknown tracker type: {tracker_type}")
 
     # Dynamically import and instantiate the correct tracker class
     module_path, class_name = tracker_mapping[tracker_type].rsplit(".", 1)

--- a/tests/unit/test_trackers.py
+++ b/tests/unit/test_trackers.py
@@ -281,15 +281,16 @@ def test_track_id_stable_over_frames(tracker_type):
     assert out1[0, 4] == out2[0, 4], "Track ID should remain the same across frames"
 
 
-# def test_create_tracker_invalid_tracker_name():
-#     """Creating a tracker with an unknown name should raise a ValueError."""
-#     with pytest.raises(KeyError):
-#         # invalid tracker_type
-#         create_tracker(
-#             tracker_type="nonexistent_tracker",
-#             tracker_config=get_tracker_config('botsort'),
-#             reid_weights=WEIGHTS / 'mobilenetv2_x1_4_dukemtmcreid.pt',
-#             device='cpu',
-#             half=False,
-#             per_class=False
-#         )
+def test_create_tracker_invalid_tracker_name():
+    """Creating a tracker with an unknown name should raise a ValueError."""
+    with pytest.raises(ValueError, match="Unknown tracker type: nonexistent_tracker"):
+        create_tracker(
+            tracker_type="nonexistent_tracker",
+            tracker_config=get_tracker_config("botsort"),
+            reid_weights=WEIGHTS / "mobilenetv2_x1_4_dukemtmcreid.pt",
+            device="cpu",
+            half=False,
+            per_class=False,
+        )
+
+


### PR DESCRIPTION
## Summary
- raise `ValueError` for unknown tracker types in `create_tracker`
- document `create_tracker` exception behavior
- keep invalid tracker test with other tracker tests

## Testing
- `PYTHONPATH=. pytest tests/unit/test_trackers.py::test_create_tracker_invalid_tracker_name -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pyyaml -q` *(ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890d53116c0832db71199a98aaebd40