### PR TITLE
Add split-and-connect tracklet postprocessing

### DIFF
--- a/tests/unit/test_postprocessing.py
+++ b/tests/unit/test_postprocessing.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from boxmot.postprocessing.gsi import gaussian_smooth, linear_interpolation
-from boxmot.postprocessing.sct import sct
+from boxmot.postprocessing.gta import gta
 
 
 def test_gsi():
@@ -18,7 +18,7 @@ def test_gsi():
     assert len(gsi) == 6
 
 
-def test_sct_merging(tmp_path):
+def test_gta_merging(tmp_path):
     data = np.array(
         [
             [1, 1, 0, 0, 1, 1, 0.9, -1, -1],
@@ -30,7 +30,7 @@ def test_sct_merging(tmp_path):
     mot_file = tmp_path / "MOT17-01.txt"
     np.savetxt(mot_file, data, delimiter=",", fmt="%.1f")
 
-    sct(mot_results_folder=tmp_path, use_split=False, use_connect=True, merge_dist_thres=0.5)
+    gta(mot_results_folder=tmp_path, use_split=False, use_connect=True, merge_dist_thres=0.5)
 
     processed = np.loadtxt(mot_file, delimiter=",")
     assert np.unique(processed[:, 1]).size == 1


### PR DESCRIPTION
## Summary
- add a split-and-connect tracklet (SCT) postprocessing pipeline for MOT result folders
- expose the SCT helper through the package API, CLI, and documentation alongside existing GSI support
- cover SCT merging with a new unit test

## Testing
- python -m pytest tests/unit/test_postprocessing.py *(fails: numpy unavailable in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693441bd2334832d905d412696311187)