### PR TITLE
Fix #2207: TypeError: only 0-dimensional arrays can be converted to Python scalars

### DIFF
--- a/boxmot/motion/kalman_filters/aabb/xysr_kf.py
+++ b/boxmot/motion/kalman_filters/aabb/xysr_kf.py
@@ -200,7 +200,7 @@ class KalmanFilterXYSR(object):
             for i in range(index2 - index1):
                 x, y = x1 + (i + 1) * dx, y1 + (i + 1) * dy
                 w, h = w1 + (i + 1) * dw, h1 + (i + 1) * dh
-                s, r = w * h, w / float(h)
+                s, r = w * h, w / float(h.squeeze())
                 new_box = np.array([x, y, s, r]).reshape((4, 1))
                 self.update(new_box)
                 if not i == (index2 - index1 - 1):


### PR DESCRIPTION
I just added .squeeze() where the error was occurring, since newer numpy wants more clarity while working with dimensions. It works now.